### PR TITLE
add checking if parent element contains no-drag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ class DragSortableList extends React.Component {
     const draggableChildrenSelector = '#' + this.ref + '> .draggable'
     const ignoreNoDrag = fun => event => {
       const mouseElement = document.elementFromPoint(event.clientX, event.clientY)
-      if(mouseElement && !mouseElement.classList.contains('no-drag')) {
+      if(mouseElement && !mouseElement.classList.contains('no-drag') && mouseElement.parent && !mouseElement.parent.classList.contains('no-drag')) {
         fun(event)
       } else {
         interact.stop(event)

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ class DragSortableList extends React.Component {
     const draggableChildrenSelector = '#' + this.ref + '> .draggable'
     const ignoreNoDrag = fun => event => {
       const mouseElement = document.elementFromPoint(event.clientX, event.clientY)
-      if(mouseElement && !mouseElement.classList.contains('no-drag') && mouseElement.parent && !mouseElement.parent.classList.contains('no-drag')) {
+      if(mouseElement && !mouseElement.classList.contains('no-drag') && mouseElement.parentNode && !mouseElement.parentNode.classList.contains('no-drag')) {
         fun(event)
       } else {
         interact.stop(event)


### PR DESCRIPTION
needed for some external plugins like material-ui components that doesn't allow to set classes to child elements - only for wrappers.