### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "webpack-dev-server": "^1.10.1"
   },
   "dependencies": {
-    "interactjs": "^1.2.8",
+    "interactjs": "1.9.4",
     "lodash": "^4.17.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
react-drag-sortable gives errors for interactjs 1.9.5-1.9.7 recently.

Source: https://github.com/taye/interact.js/issues/803

Changing version back to 1.9.4 because that's stable